### PR TITLE
Use TCP instead of IPC for ZMQ implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 ## Using this repo
 
-To run the simulator, first make sure the `/tmp/robo_sim` directory exists.
-Then you will need to run the following scripts at once.
+To run the simulator, open two terminals. Then you will need to run the following scripts one in each terminal. In a conda prompt shell, the following commands 
+would work.
 
 ```
-./broker.py
-./simulator.py which_map.json
+python broker.py
+python simulator.py which_map.json
 ```
+
+
+## broker.py and simulator.py
 
 The broker script makes the ZeroMQ messaging easier. All nodes publish to the
 broker and subscribe to the broker. The broker forwards all messages to all the
@@ -44,7 +47,10 @@ converted into raw bytes with the `encode()` function.
 
 ```python
 pub_socket = context.socket(zmq.PUB)
-pub_socket.connect("ipc:///tmp/robo_sim/pub.ipc")
+
+# pub_socket.connect("ipc://file_path/pub.ipc") #-----  Alternative approach using files instead of TCP.
+pub_socket.connect("tcp://localhost:5557") 
+
 
 message_dict = {"key1": 20, "key2": "a string"}
 message_str = json.dumps(message_dict)
@@ -58,7 +64,9 @@ convert it back to a dictionary using the `loads()` function.
 
 ```python
 sub_socket = context.socket(zmq.SUB)
-sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc")
+# sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc") #-----  Alternative approach using files instead of TCP.
+sub_socket.connect("tcp://localhost:5555") 
+
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"my_nifty_topic")
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"second_nifty_topic")
 

--- a/broker.py
+++ b/broker.py
@@ -11,10 +11,12 @@ import time
 context = zmq.Context()
 
 pub_socket = context.socket(zmq.PUB)
-pub_socket.bind("ipc:///tmp/robo_sim/sub.ipc")
+# pub_socket.bind("ipc:///tmp/robo_sim/sub.ipc")
+pub_socket.bind("tcp://*:5555")
 
 sub_socket = context.socket(zmq.SUB)
-sub_socket.bind("ipc:///tmp/robo_sim/pub.ipc")
+# sub_socket.bind("ipc:///tmp/robo_sim/pub.ipc")
+sub_socket.bind("tcp://*:5557")
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"")
 
 

--- a/simulator.py
+++ b/simulator.py
@@ -27,10 +27,13 @@ map_name = args.map
 context = zmq.Context()
 
 pub_socket = context.socket(zmq.PUB)
-pub_socket.connect("ipc:///tmp/robo_sim/pub.ipc")
+# pub_socket.connect("ipc:///tmp/robo_sim/pub.ipc")
+pub_socket.connect("tcp://localhost:5557")
 
 sub_socket = context.socket(zmq.SUB)
-sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc")
+# sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc")
+sub_socket.connect("tcp://localhost:5555")
+
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"wheel_speeds")
 
 robot_width = 0.1

--- a/test_controller.py
+++ b/test_controller.py
@@ -14,10 +14,13 @@ import numpy as np
 context = zmq.Context()
 
 pub_socket = context.socket(zmq.PUB)
-pub_socket.connect("ipc:///tmp/robo_sim/pub.ipc")
+# pub_socket.connect("ipc:///tmp/robo_sim/pub.ipc")
+pub_socket.connect("tcp://localhost:5557")
 
 sub_socket = context.socket(zmq.SUB)
-sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc")
+# sub_socket.connect("ipc:///tmp/robo_sim/sub.ipc")
+sub_socket.connect("tcp://localhost:5555")
+
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"state")
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"collision")
 sub_socket.setsockopt(zmq.SUBSCRIBE, b"lidar")


### PR DESCRIPTION
With this change, we don't need a /tmp/robo_sim directory. Mostly for Windows users.